### PR TITLE
Hotfix: added version to search_form.js

### DIFF
--- a/inc/search-form/search-form.php
+++ b/inc/search-form/search-form.php
@@ -29,7 +29,7 @@ $waiting_page = $search_flow_config["waiting_page"];
     
 </form>
 
-<script src="<?php echo $searchflow_path ?>js/search_form.js"></script>
+<script src="<?php echo $searchflow_path ?>js/search_form.js?v=2022-06-30-1"></script>
 
 <script>
 var search_options_object;


### PR DESCRIPTION
Version stamp added to the `search_form.js` script import in search flow's search form. This should force the browsers not to use the cached version of the script and therefore prevent the search form bug that occured multiple times.