### PR TITLE
Db connection errorhandling

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -189,6 +189,7 @@ if(isset($search_flow_config_local)) {
                 , "API error: PubMed not reachable": "pubmed_500_error"
                 , "unexpected PubMed API error": "pubmed_unexpected_error"
                 , "unexpected data processing error": "server_error"
+                , "database connection error": "database_connection_error"
                 , "dataprocessing rate limit": "rate_limit"
                 , "API error: BASE not reachable": "base_xml_error"
                 , "BASE error: timeout": "base_timeout_error"
@@ -239,6 +240,15 @@ if(isset($search_flow_config_local)) {
             server_error: {
                 title: "Sorry! An unexpected error occurred."
                 , reason: 'Unfortunately we don’t know what went wrong. We apologize for the inconvenience. Please <a id="fail-index" class="underline" href="index.php">try again</a> in a few minutes.'
+                , remedy: 'If the error persists, please let us know at <a class="underline" href="mailto:info@openknowledgemaps.org">info@openknowledgemaps.org</a>. We will investigate the issue further.'
+                , resolution_type: "link"
+                , resolution_label: "Try again"
+                , resolution_link: "index"
+
+            },
+            database_connection_error: {
+                title: "Database connection lost"
+                , reason: 'At the moment we are unable to establish a connection to our database. This can have a number of reasons, most likely our server is down. As a result we can’t create a visualisation for your query. Please <a href="index.php">try again</a> in a few minutes.'
                 , remedy: 'If the error persists, please let us know at <a class="underline" href="mailto:info@openknowledgemaps.org">info@openknowledgemaps.org</a>. We will investigate the issue further.'
                 , resolution_type: "link"
                 , resolution_label: "Try again"

--- a/conf/config.php
+++ b/conf/config.php
@@ -248,7 +248,7 @@ if(isset($search_flow_config_local)) {
             },
             database_connection_error: {
                 title: "Database connection lost"
-                , reason: 'At the moment we are unable to establish a connection to our database. This can have a number of reasons, most likely our server is down. As a result we can’t create a visualisation for your query. Please <a href="index.php">try again</a> in a few minutes.'
+                , reason: 'At the moment we are unable to establish a connection to our database. This can have a number of reasons, most likely our server is down. As a result we can’t create a visualisation for your query. Please <a class="underline" href="index.php">try again</a> in a few minutes.'
                 , remedy: 'If the error persists, please let us know at <a class="underline" href="mailto:info@openknowledgemaps.org">info@openknowledgemaps.org</a>. We will investigate the issue further.'
                 , resolution_type: "link"
                 , resolution_label: "Try again"

--- a/inc/search-form/search-form.php
+++ b/inc/search-form/search-form.php
@@ -8,7 +8,8 @@ $waiting_page = $search_flow_config["waiting_page"];
 <link rel="stylesheet" href="<?php echo $searchflow_path ?>lib/font-awesome.min.css">
 <link rel="stylesheet" href="<?php echo $searchflow_path ?>css/options.css">
 
-<form id="searchform" action="#" method="POST" class="center-div2" target="_blank">
+#TODO: Revert to the original version of the search form before merge to master
+<form id="searchform" action="#" method="POST" class="center-div2">
     
     <div class="searchform-div">
         <p class="library"></p>

--- a/inc/search-form/search-form.php
+++ b/inc/search-form/search-form.php
@@ -8,8 +8,7 @@ $waiting_page = $search_flow_config["waiting_page"];
 <link rel="stylesheet" href="<?php echo $searchflow_path ?>lib/font-awesome.min.css">
 <link rel="stylesheet" href="<?php echo $searchflow_path ?>css/options.css">
 
-<!-- TODO: Revert to original search form before merge to master, we changed the target=blank behavior for debugging purposes -->
-<form id="searchform" action="#" method="POST" class="center-div2">
+<form id="searchform" action="#" method="POST" class="center-div2" target="_blank">
     
     <div class="searchform-div">
         <p class="library"></p>

--- a/inc/search-form/search-form.php
+++ b/inc/search-form/search-form.php
@@ -8,7 +8,7 @@ $waiting_page = $search_flow_config["waiting_page"];
 <link rel="stylesheet" href="<?php echo $searchflow_path ?>lib/font-awesome.min.css">
 <link rel="stylesheet" href="<?php echo $searchflow_path ?>css/options.css">
 
-#TODO: Revert to the original version of the search form before merge to master
+<!-- TODO: Revert to original search form before merge to master, we changed the target=blank behavior for debugging purposes -->
 <form id="searchform" action="#" method="POST" class="center-div2">
     
     <div class="searchform-div">

--- a/inc/visualization/visualization-header.php
+++ b/inc/visualization/visualization-header.php
@@ -26,11 +26,17 @@ $has_custom_title = ($custom_title !== false)?(true):(false);
 $is_embed = getParam("embed", INPUT_GET, FILTER_VALIDATE_BOOLEAN, true) || $search_flow_config["force_embed"];
 
 if($search_flow_config["vis_load_context"]) {
+    // the following request should respond with the proper error code, e.g. a 503 for db connection errors
     if ($docker_internal) {
         $context_json = curl_get_contents($protocol . $headstart_path_docker_internal . "server/services/getContext.php?vis_id=$id");
     } else {
         $context_json = curl_get_contents($protocol . $headstart_path . "server/services/getContext.php?vis_id=$id");
     }
+    // error_log("visalization-header.php Context JSON: " . $context_json);
+    // Check if context is not available yet
+    // if it does reply with an error code we should bail before anything else happens
+    // instead of rendering vis page we should render an error page with the error code
+    // either by a redirect to a dedicated error page or by rendering the error page directly
     $context = json_decode($context_json);
 
     $service = setVariableFromContext($context

--- a/inc/visualization/visualization-header.php
+++ b/inc/visualization/visualization-header.php
@@ -32,6 +32,8 @@ if($search_flow_config["vis_load_context"]) {
     } else {
         $context_json = curl_get_contents($protocol . $headstart_path . "server/services/getContext.php?vis_id=$id");
     }
+    // This is the earliest we can possibly know that the context could not be loaded
+    // We probably already want to throw a 404 here
     // error_log("visalization-header.php Context JSON: " . $context_json);
     // Check if context is not available yet
     // if it does reply with an error code we should bail before anything else happens

--- a/js/search.js
+++ b/js/search.js
@@ -149,6 +149,7 @@ function executeSearchRequest(
   vis_page
 ) {
   $.ajax({
+    //todo: this returns success=true even if the database server is not reachable
     url: service_url,
     type: "POST",
     data: post_data,


### PR DESCRIPTION
This PR introduces new functionality in the search-flow:

- In case of a connection loss to the database server, users will now see a dedicated error message in the search-flow, instead of being redirected to a 404 page.

Other changes:

- Try-out links have been replaced by dynamic search requests. They will now also show those errors.