### PR TITLE
Bugfix/searchbox servicesoption

### DIFF
--- a/js/searchbox/components/DataSource.js
+++ b/js/searchbox/components/DataSource.js
@@ -7,10 +7,11 @@ import SERVICES_OPTIONS from "../options/services.js";
 const e = React.createElement;
 
 const DataSource = ({value, setValue}) => {
+    const filteredOptions = SERVICES_OPTIONS.filter(option => option.id !== 'orcid');
     return e("div", {className: "datasource-style"},
         e(RadioInputList, {
             label: "Select a data source",
-            options: SERVICES_OPTIONS,
+            options: filteredOptions,
             name: "service",
             value: value,
             setValue: setValue,


### PR DESCRIPTION
This PR fixes a bug where the ORCID option is shown when "show_service" parameter is True. The correct behavior is that only BASE and PubMed data source options are shown in the search box when "show_service" parameter is True.