### PR TITLE
refactor: remove deprecated code constructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Folders
 /nbproject/private/
 vendor/
+.idea/
+.vscode/
 
 # Files
 /config_local.ini

--- a/inc/how-it-works/how-it-works.php
+++ b/inc/how-it-works/how-it-works.php
@@ -1,12 +1,23 @@
 <?php
 include_once dirname(__FILE__). '../../../php/get-params.php';
 
-$service = getParam("service", INPUT_GET, FILTER_SANITIZE_STRING, true);
-$vis_type = getParam("vis_type", INPUT_GET, FILTER_SANITIZE_STRING, true, true);
+$service_raw = getParam("service", INPUT_GET, null, true);
+$vis_type_raw = getParam("vis_type", INPUT_GET, null, true, true);
 
-if (substr($service, -2) === 'sg' || $vis_type === 'timeline' || (isset($post_array) && isset($post_array["vis_type"]) && $post_array["vis_type"] === 'timeline')) {
-    include('streamgraph.php');
+$service = is_string($service_raw) ? htmlspecialchars($service_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
+$vis_type = is_string($vis_type_raw) ? htmlspecialchars($vis_type_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
+
+$is_vis_type_is_timeline = $vis_type === 'timeline';
+$is_service_name_contains_sg_letters = substr($service, -2) === 'sg';
+$is_post_array_contains_timeline_vis_type = (isset($post_array) && isset($post_array['vis_type']) && $post_array['vis_type'] === 'timeline');
+
+if (
+  $is_vis_type_is_timeline ||
+  $is_service_name_contains_sg_letters ||
+  $is_post_array_contains_timeline_vis_type
+) {
+  include('streamgraph.php');
 } else {
-    include('knowledge-map.php');
+  include('knowledge-map.php');
 }
 ?>

--- a/inc/how-it-works/how-it-works.php
+++ b/inc/how-it-works/how-it-works.php
@@ -1,11 +1,13 @@
 <?php
-include_once dirname(__FILE__). '../../../php/get-params.php';
+
+include_once dirname(__FILE__) . '../../../php/get-params.php';
+include_once dirname(__FILE__) . '../../../php/sanitize-string.php';
 
 $service_raw = getParam("service", INPUT_GET, null, true);
 $vis_type_raw = getParam("vis_type", INPUT_GET, null, true, true);
 
-$service = is_string($service_raw) ? htmlspecialchars($service_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
-$vis_type = is_string($vis_type_raw) ? htmlspecialchars($vis_type_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
+$service = sanitize_string($service_raw);
+$vis_type = sanitize_string($vis_type_raw);
 
 $is_vis_type_is_timeline = $vis_type === 'timeline';
 $is_service_name_contains_sg_letters = substr($service, -2) === 'sg';
@@ -20,4 +22,5 @@ if (
 } else {
   include('knowledge-map.php');
 }
+
 ?>

--- a/inc/visualization/visualization-header.php
+++ b/inc/visualization/visualization-header.php
@@ -5,23 +5,21 @@ include_once dirname(__FILE__). '../../../php/header-head.php';
 $docker_internal = loadConfigOption($ini_array, "docker_internal", "general");
 $headstart_path_docker_internal = loadConfigOption($ini_array, "headstart_path_docker_internal", "general");
 
-$id = getParam("id", INPUT_GET, FILTER_SANITIZE_STRING, true);
+$id_raw = getParam("id", INPUT_GET, FILTER_DEFAULT, true);
+$id = is_string($id_raw) ? htmlspecialchars($id_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
 if ($search_flow_config["enable_default_id"] && ($id === false || $id === "")) {
     $id = $search_flow_config["default_id"];
 }
 
-$vis_type = getParam("vis_type", INPUT_GET, FILTER_SANITIZE_STRING, true, true);
-$has_vis_type = ($vis_type === false)?(false):(true);
+$vis_type_raw = getParam("vis_type", INPUT_GET, FILTER_DEFAULT, true, true);
+$vis_type = is_string($vis_type_raw) ? htmlspecialchars($vis_type_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
+$has_vis_type = ($vis_type === false || $vis_type === '') ? false : true;
 
-$protocol_server = getParam("HTTPS", INPUT_SERVER, FILTER_SANITIZE_STRING, true, true);
-$protocol = $protocol_server !== false && $protocol_server !== 'off' ? 'https:' : 'http:';
+$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https:' : 'http:';
 
-$custom_title = 
-        ($search_flow_config["enable_custom_title"])
-            ?(getParam("custom_title", INPUT_GET, FILTER_SANITIZE_STRING, true, true))
-            :(false);
-
-$has_custom_title = ($custom_title !== false)?(true):(false);
+$custom_title_raw = getParam("custom_title", INPUT_GET, FILTER_DEFAULT, true, true);
+$custom_title = is_string($custom_title_raw) ? htmlspecialchars($custom_title_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : false;
+$has_custom_title = ($custom_title !== false && $custom_title !== '') ? true : false;
 
 $is_embed = getParam("embed", INPUT_GET, FILTER_VALIDATE_BOOLEAN, true) || $search_flow_config["force_embed"];
 
@@ -65,7 +63,7 @@ if($search_flow_config["vis_load_context"]) {
                                  : ("n.d.");
 
     // Decode the "params" JSON string to an associative array from the context
-    $params = json_decode($context->params, true);
+    $params = isset($context->params) ? json_decode($context->params, true) : [];
 
     // Set the $custom_title_from_context variable based on the context
     if (isset($params["custom_title"])) {

--- a/inc/visualization/visualization-header.php
+++ b/inc/visualization/visualization-header.php
@@ -1,24 +1,25 @@
 <?php
 include_once dirname(__FILE__). '../../../conf/config.php';
 include_once dirname(__FILE__). '../../../php/header-head.php';
+include_once dirname(__FILE__) . '../../../php/sanitize-string.php';
 
 $docker_internal = loadConfigOption($ini_array, "docker_internal", "general");
 $headstart_path_docker_internal = loadConfigOption($ini_array, "headstart_path_docker_internal", "general");
 
 $id_raw = getParam("id", INPUT_GET, FILTER_DEFAULT, true);
-$id = is_string($id_raw) ? htmlspecialchars($id_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
+$id = sanitize_string($id_raw);
 if ($search_flow_config["enable_default_id"] && ($id === false || $id === "")) {
     $id = $search_flow_config["default_id"];
 }
 
 $vis_type_raw = getParam("vis_type", INPUT_GET, FILTER_DEFAULT, true, true);
-$vis_type = is_string($vis_type_raw) ? htmlspecialchars($vis_type_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : '';
+$vis_type = sanitize_string($vis_type_raw);
 $has_vis_type = ($vis_type === false || $vis_type === '') ? false : true;
 
 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https:' : 'http:';
 
 $custom_title_raw = getParam("custom_title", INPUT_GET, FILTER_DEFAULT, true, true);
-$custom_title = is_string($custom_title_raw) ? htmlspecialchars($custom_title_raw, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') : false;
+$custom_title = sanitize_string($custom_title_raw);
 $has_custom_title = ($custom_title !== false && $custom_title !== '') ? true : false;
 
 $is_embed = getParam("embed", INPUT_GET, FILTER_VALIDATE_BOOLEAN, true) || $search_flow_config["force_embed"];

--- a/inc/visualization/visualization-header.php
+++ b/inc/visualization/visualization-header.php
@@ -16,7 +16,9 @@ $vis_type_raw = getParam("vis_type", INPUT_GET, FILTER_DEFAULT, true, true);
 $vis_type = sanitize_string($vis_type_raw);
 $has_vis_type = ($vis_type === false || $vis_type === '') ? false : true;
 
-$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https:' : 'http:';
+$protocol_server_raw = getParam("HTTPS", INPUT_SERVER, FILTER_DEFAULT, true, true);
+$protocol_server = sanitize_string($protocol_server_raw);
+$protocol = $protocol_server !== '' && $protocol_server !== 'off' ? 'https:' : 'http:';
 
 $custom_title_raw = getParam("custom_title", INPUT_GET, FILTER_DEFAULT, true, true);
 $custom_title = sanitize_string($custom_title_raw);

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -187,7 +187,9 @@ switch ($service) {
         break;
 }
 
-$get_q_advanced = getParam("q_advanced", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+$get_q_advanced_raw = getParam("q_advanced", INPUT_GET, FILTER_DEFAULT, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+$get_q_advanced = sanitize_if_string($get_q_advanced_raw);
+
 $unique_id = "";
 $dirty_query = "";
 $dirty_q_advanced = "";

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -2,6 +2,7 @@
 include_once dirname(__FILE__) . '../../../php/load-config.php';
 include_once dirname(__FILE__) . '../../../php/get-params.php';
 include_once dirname(__FILE__) . '../../../php/sanitize-string.php';
+include_once dirname(__FILE__) . '../../../php/sanitize-if-string.php';
 include_once dirname(__FILE__) . '../../../conf/config.php';
 
 $ini_array = loadConfigFile();
@@ -83,9 +84,11 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
             $param = $options["id"];
 
             if ($options["multiple"] === true) {
-                $param_get = getParam($param, INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_REQUIRE_ARRAY]);
+                $param_get_raw = getParam($param, INPUT_GET, FILTER_DEFAULT, true, true, ['flags' => FILTER_REQUIRE_ARRAY]);
+                $param_get = sanitize_if_string($param_get_raw);
             } else {
-                $param_get = getParam($param, INPUT_GET, FILTER_SANITIZE_STRING, true, true);
+                $param_get_raw = getParam($param, INPUT_GET, FILTER_DEFAULT, true, true);
+                $param_get = sanitize_if_string($param_get_raw);
             }
 
             if ($param_get !== false) {

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -83,7 +83,7 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
             $param = $options["id"];
 
             if ($options["multiple"] === true) {
-                $param_get = getParam($param, INPUT_GET, FILTER_SANITIZE_STRING, true, true, FILTER_REQUIRE_ARRAY);
+                $param_get = getParam($param, INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_REQUIRE_ARRAY]);
             } else {
                 $param_get = getParam($param, INPUT_GET, FILTER_SANITIZE_STRING, true, true);
             }
@@ -147,7 +147,7 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
         foreach ($search_flow_config["optional_get_params"][$service] as $optional_param => $optional_param_type) {
             if ($optional_param_type === "array") {
                 // force string to array conversion for backward compatibility of GET-API
-                $param_get = getParam($optional_param, INPUT_GET, FILTER_SANITIZE_STRING, true, true, FILTER_FORCE_ARRAY);
+                $param_get = getParam($optional_param, INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FORCE_ARRAY]);
             } else {
                 $param_get = getParam($optional_param, INPUT_GET, FILTER_SANITIZE_STRING, true, true);
             }
@@ -164,17 +164,17 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
 $request_type = getParam("type", INPUT_GET, FILTER_SANITIZE_STRING, true, true);
 switch ($service) {
     case "openaire":
-        $get_query = getParam("project_id", INPUT_GET, FILTER_SANITIZE_STRING, true, true, FILTER_FLAG_NO_ENCODE_QUOTES);
+        $get_query = getParam("project_id", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
         break;
     case "orcid":
-        $get_query = getParam("orcid", INPUT_GET, FILTER_SANITIZE_STRING, true, true, FILTER_FLAG_NO_ENCODE_QUOTES);
+        $get_query = getParam("orcid", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
         break;
     default:
-        $get_query = getParam("q", INPUT_GET, FILTER_SANITIZE_STRING, true, true, FILTER_FLAG_NO_ENCODE_QUOTES);
+        $get_query = getParam("q", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
         break;
 }
 
-$get_q_advanced = getParam("q_advanced", INPUT_GET, FILTER_SANITIZE_STRING, true, true, FILTER_FLAG_NO_ENCODE_QUOTES);
+$get_q_advanced = getParam("q_advanced", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
 $unique_id = "";
 $dirty_query = "";
 $dirty_q_advanced = "";

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -1,6 +1,7 @@
 <?php
 include_once dirname(__FILE__) . '../../../php/load-config.php';
 include_once dirname(__FILE__) . '../../../php/get-params.php';
+include_once dirname(__FILE__) . '../../../php/sanitize-string.php';
 include_once dirname(__FILE__) . '../../../conf/config.php';
 
 $ini_array = loadConfigFile();

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -153,9 +153,11 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
         foreach ($search_flow_config["optional_get_params"][$service] as $optional_param => $optional_param_type) {
             if ($optional_param_type === "array") {
                 // force string to array conversion for backward compatibility of GET-API
-                $param_get = getParam($optional_param, INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FORCE_ARRAY]);
+                $param_get_raw = getParam($optional_param, INPUT_GET, FILTER_DEFAULT, true, true, ['flags' => FILTER_FORCE_ARRAY]);
+                $param_get = sanitize_if_string($param_get_raw);
             } else {
-                $param_get = getParam($optional_param, INPUT_GET, FILTER_SANITIZE_STRING, true, true);
+                $param_get_raw = getParam($optional_param, INPUT_GET, FILTER_DEFAULT, true, true);
+                $param_get = sanitize_if_string($param_get_raw);
             }
             // prevent double string sanitization for q_advanced
             if ($param_get !== false && $optional_param != "q_advanced") {

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -24,16 +24,15 @@ function logToConsole($data)
     echo "<script>console.log('Debug Objects: " . $output . "' );</script>";
 }
 
-// This fixes a bug in iOS Safari where an inactive tab would forget the post 
+// This fixes a bug in iOS Safari where an inactive tab would forget the post
 // parameters - usually when the user opens a different tab while waiting for
 // a map to be created.
-$service = getParam("service", INPUT_GET, FILTER_SANITIZE_STRING, true);
-$id_param = getParam("id", INPUT_GET, FILTER_SANITIZE_STRING, true);
-if ($id_param === false) {
-    $id_param = "";
-}
-
 $is_embed = getParam("embed", INPUT_GET, FILTER_VALIDATE_BOOLEAN, true) || $search_flow_config["force_embed"];
+$service_raw = getParam("service", INPUT_GET, FILTER_DEFAULT, true);
+$id_param_raw = getParam("id", INPUT_GET, FILTER_DEFAULT, true);
+
+$service = sanitize_string($service_raw);
+$id_param = sanitize_string($id_param_raw);
 
 if (
     isset($_SESSION['post']) && isset($_SESSION['post'][$id_param]) && isset($_SESSION['post'][$id_param]["unique_id"])

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -169,16 +169,21 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
     return $ret_array;
 }
 
-$request_type = getParam("type", INPUT_GET, FILTER_SANITIZE_STRING, true, true);
+$request_type_raw = getParam("type", INPUT_GET, FILTER_DEFAULT, true, true);
+$request_type = sanitize_if_string($request_type_raw);
+
 switch ($service) {
     case "openaire":
-        $get_query = getParam("project_id", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+        $get_query_raw = getParam("project_id", INPUT_GET, FILTER_DEFAULT, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+        $get_query = sanitize_if_string($get_query_raw);
         break;
     case "orcid":
-        $get_query = getParam("orcid", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+        $get_query_raw = getParam("orcid", INPUT_GET, FILTER_DEFAULT, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+        $get_query = sanitize_if_string($get_query_raw);
         break;
     default:
-        $get_query = getParam("q", INPUT_GET, FILTER_SANITIZE_STRING, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+        $get_query_raw = getParam("q", INPUT_GET, FILTER_DEFAULT, true, true, ['flags' => FILTER_FLAG_NO_ENCODE_QUOTES]);
+        $get_query = sanitize_if_string($get_query_raw);
         break;
 }
 

--- a/inc/waiting-page/waiting-page.php
+++ b/inc/waiting-page/waiting-page.php
@@ -99,8 +99,11 @@ function createGetRequestArray($get_query, $service, $filter_options, $get_q_adv
                     $range = ($options["id"] === "time_range") ? ("time_range") : ("year_range");
                     $is_custom_date = false;
 
-                    $param_from = getParam("from", INPUT_GET, FILTER_SANITIZE_STRING, true, true);
-                    $param_to = getParam("to", INPUT_GET, FILTER_SANITIZE_STRING, true, true);
+                    $param_from_raw = getParam("from", INPUT_GET, FILTER_DEFAULT, true, true);
+                    $param_to_raw = getParam("to", INPUT_GET, FILTER_DEFAULT, true, true);
+
+                    $param_from = sanitize_if_string($param_from_raw);
+                    $param_to = sanitize_if_string($param_to_raw);
 
                     if ($param_from === false) {
                         $ret_array["from"] = $current_options["start_date"];

--- a/php/get-params.php
+++ b/php/get-params.php
@@ -1,35 +1,44 @@
 <?php
 
-// Returns parameter or false in case of error/filter failure
-function getParam($param, $where = INPUT_GET, $filter = FILTER_SANITIZE_STRING
-                    , $return_false_nonexistent = false
-                    , $return_false_null = false
-                    , $options = array()) {
-    
-   $boolean_filter = $filter === FILTER_VALIDATE_BOOLEAN;
-    
-   $return_param = filter_input($where, $param, $filter, $options);
-    
-    if(!$boolean_filter && $return_param === false) {
-        die("An error ocurred while retrieving the following parameter: " . $param);
-    } else if($boolean_filter && $return_param === null) {
+// Returns parameter or false (in case of error/filter failure)
+function getParam(
+    string $param,
+    int $where = INPUT_GET,
+    ?int $filter = FILTER_DEFAULT,
+    bool $return_false_nonexistent = false,
+    bool $return_false_null = false,
+    array $options = []
+) {
+    $boolean_filter = $filter === FILTER_VALIDATE_BOOLEAN;
+
+    // PHP 8.1+: filter must be int, not null
+    // This if statement check that it is int or using FILTER_DEFAULT
+    if ($filter !== null) {
+        $return_param = !empty($options)
+            ? filter_input($where, $param, $filter, ['options' => $options])
+            : filter_input($where, $param, $filter);
+    } else {
+        $return_param = filter_input($where, $param, FILTER_DEFAULT);
+    }
+
+    if (!$boolean_filter && $return_param === false) {
+        die("An error occurred while retrieving the following parameter: {$param}");
+    } else if ($boolean_filter && $return_param === null) {
         return false;
     }
 
-    if($return_param === false) {
-        if($filter === FILTER_VALIDATE_BOOLEAN) {
+    if ($return_param === false) {
+        if ($filter === FILTER_VALIDATE_BOOLEAN) {
             return false;
         } else if ($return_false_nonexistent === true) {
             return false;
         } else {
-            die("The following parameter does not exist: ". $param);
+            die("The following parameter does not exist: {$param}");
         }
     }
-    
-    if($return_false_null) {
-        if($return_param === null) {
-            return false;
-        }
+
+    if ($return_false_null && $return_param === null) {
+        return false;
     }
 
     return $return_param;

--- a/php/get-params.php
+++ b/php/get-params.php
@@ -11,32 +11,24 @@ function getParam(
 ) {
     $boolean_filter = $filter === FILTER_VALIDATE_BOOLEAN;
 
-    // PHP 8.1+: filter must be int, not null
-    // This if statement check that it is int or using FILTER_DEFAULT
-    if ($filter !== null) {
-        $return_param = !empty($options)
-            ? filter_input($where, $param, $filter, ['options' => $options])
-            : filter_input($where, $param, $filter);
-    } else {
-        $return_param = filter_input($where, $param, FILTER_DEFAULT);
-    }
+    $has_options = !empty($options);
+    $filter_value = $filter ?? FILTER_DEFAULT;
 
-    if (!$boolean_filter && $return_param === false) {
-        die("An error occurred while retrieving the following parameter: {$param}");
-    } else if ($boolean_filter && $return_param === null) {
+    $return_param = $has_options
+        ? filter_input($where, $param, $filter_value, ['options' => $options])
+        : filter_input($where, $param, $filter_value);
+
+    // Return false if parameter is not exists or is not equals to flag (for example - not an array)
+    if ($return_param === false) {
+        // ..., but if this parameter was required — die()
+        if (!$boolean_filter && !$return_false_nonexistent) {
+            die("An error ocurred while retrieving the following parameter: " . $param);
+        }
+
         return false;
     }
 
-    if ($return_param === false) {
-        if ($filter === FILTER_VALIDATE_BOOLEAN) {
-            return false;
-        } else if ($return_false_nonexistent === true) {
-            return false;
-        } else {
-            die("The following parameter does not exist: {$param}");
-        }
-    }
-
+    // If its required to return false when param is equal null
     if ($return_false_null && $return_param === null) {
         return false;
     }

--- a/php/get-params.php
+++ b/php/get-params.php
@@ -22,7 +22,7 @@ function getParam(
     if ($return_param === false) {
         // ..., but if this parameter was required — die()
         if (!$boolean_filter && !$return_false_nonexistent) {
-            die("An error ocurred while retrieving the following parameter: " . $param);
+            die("An error occurred while retrieving the following parameter: " . $param);
         }
 
         return false;

--- a/php/sanitize-if-string.php
+++ b/php/sanitize-if-string.php
@@ -1,0 +1,21 @@
+<?php
+
+include_once dirname(__FILE__) . '/sanitize-string.php';
+
+/**
+ * Sanitizing string if it was passed. If received value is not a string it
+ * will be returned without any changes.
+ * @param mixed $value - Possible string to be sanitized.
+ * @return mixed - Sanitized string or other received value without changes.
+ */
+function sanitize_if_string(mixed $value): mixed {
+  // Check that received value is a string
+  if (is_string($value)) {
+      return sanitize_string($value);
+  }
+
+  // If value is not a string it will be returned without changes
+  return $value;
+}
+
+?>

--- a/php/sanitize-string.php
+++ b/php/sanitize-string.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Safely encodes string for HTML context.
+ * @param mixed $value - Value that must be encoded.
+ * @param int $flags - Flags of the htmlspecialchars in-built function.
+ * @param string $encoding - Encoding format.
+ * @param string $default - Default value that will be returned if $value is not a string.
+ * @return string - Encoded string or $default.
+ */
+function sanitize_string(
+  mixed $value,
+  int $flags = ENT_QUOTES | ENT_SUBSTITUTE,
+  string $encoding = 'UTF-8',
+  string $default = ''): string {
+    return is_string($value) ? htmlspecialchars($value, $flags, $encoding) : $default;
+}
+
+?>


### PR DESCRIPTION
In the `how-it-works.php`, `visualization-header.php`, `waiting-page.php` were using the deprecated filter - [`FILTER_SANITIZE_STRING`](https://www.php.net/manual/en/filter.constants.php#constant.filter-sanitize-string) and its usage has been replaced with the actual code constriction.

The `getParam` function has been updated - typing has been added, now the process doesn't die if a parameter is not defined and it is not required.

Two new functions have been added: `sanitize_if_string` and `sanitize_string`: 
1. The `sanitize_if_string` function checks if the received value is a string and, if it is, it calls the `sanitize_string` function and returns the result of its work. If not, it returns the value without changes;
2. The `sanitize_string` function uses the built-in `htmlspecialchars` function with flags to clear and make the string safe. If a non-string was passed, this function may return some default value (default is an empty string).

By the way, `.gitignore` file has been updated - added formatting by accessory: file/folder. Also added new exceptions.